### PR TITLE
Add GitHub Actions for win64-ucrt build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: MSYS2
+on: [push, pull_request]
+
+jobs:
+  msys2-ucrt64:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: make mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-freetype
+      - name: CI-Build
+        run: |
+          echo 'Running in MSYS2!'
+          make
+          pwd
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with: 
+          name: Win64-UCRT
+          path: ./*.exe
+          retention-days: 90
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ./*.exe


### PR DESCRIPTION
Use GitHub Actions to automatically build 3 exes and upload the artifact in case anyone would like to download the binarys for Windows.